### PR TITLE
Fix JS target and Erlang float formatting

### DIFF
--- a/src/fmglee.gleam
+++ b/src/fmglee.gleam
@@ -150,7 +150,7 @@ pub fn sprintf(s: String, with v: List(Fmt)) -> String {
 /// the placeholder and the value, or if the number of placeholders
 /// does not match the number of values given.
 pub fn try_sprintf(s: String, with v: List(Fmt)) -> Result(String, FmtError) {
-  let assert Ok(re) = regex.from_string("(\\%d|\\%s|\\%[\\W]?f|%[\\W]?\\.\\df)")
+  let assert Ok(re) = regex.from_string("(%d|%s|%[\\W]?f|%[\\W]?\\.\\df)")
   let matches =
     regex.scan(re, s)
     |> list.map(fn(m) { m.content })

--- a/test/fmglee_test.gleam
+++ b/test/fmglee_test.gleam
@@ -81,7 +81,21 @@ pub fn try_fmt_float_decimal_test() {
   |> should.equal(Ok("3.14"))
 }
 
+pub fn try_fmt_float_decimal_negative_test() {
+  fmglee.new("%.2f")
+  |> fmglee.f(-3.1415926)
+  |> fmglee.try_build
+  |> should.equal(Ok("-3.14"))
+}
+
 pub fn try_fmt_float_decimal_less_test() {
+  fmglee.new("%.2f")
+  |> fmglee.f(-1.0)
+  |> fmglee.try_build
+  |> should.equal(Ok("-1.00"))
+}
+
+pub fn try_fmt_float_decimal_less_negative_test() {
   fmglee.new("%.2f")
   |> fmglee.f(1.0)
   |> fmglee.try_build
@@ -95,11 +109,25 @@ pub fn try_fmt_float_delimiter_test() {
   |> should.equal(Ok("1,234.0"))
 }
 
+pub fn try_fmt_float_delimiter_negative_test() {
+  fmglee.new("%,f")
+  |> fmglee.f(-1234.0)
+  |> fmglee.try_build
+  |> should.equal(Ok("-1,234.0"))
+}
+
 pub fn try_fmt_float_delimiter_no_remainder_test() {
   fmglee.new("%,.0f")
   |> fmglee.f(1234.0)
   |> fmglee.try_build
   |> should.equal(Ok("1,234"))
+}
+
+pub fn try_fmt_float_delimiter_no_remainder_negative_test() {
+  fmglee.new("%,.0f")
+  |> fmglee.f(-1234.0)
+  |> fmglee.try_build
+  |> should.equal(Ok("-1,234"))
 }
 
 pub fn try_fmt_float_round_no_remainder_test() {
@@ -109,11 +137,25 @@ pub fn try_fmt_float_round_no_remainder_test() {
   |> should.equal(Ok("1234"))
 }
 
+pub fn try_fmt_float_round_no_remainder_negative_test() {
+  fmglee.new("%.0f")
+  |> fmglee.f(-1234.1234)
+  |> fmglee.try_build
+  |> should.equal(Ok("-1234"))
+}
+
 pub fn try_fmt_float_really_small_test() {
   fmglee.new("%.9f")
   |> fmglee.f(0.000001415926)
   |> fmglee.try_build
   |> should.equal(Ok("0.000001415"))
+}
+
+pub fn try_fmt_float_really_small_negative_test() {
+  fmglee.new("%.9f")
+  |> fmglee.f(-0.000001415926)
+  |> fmglee.try_build
+  |> should.equal(Ok("-0.000001415"))
 }
 
 pub fn try_fmt_float_really_large_test() {
@@ -123,9 +165,23 @@ pub fn try_fmt_float_really_large_test() {
   |> should.equal(Ok("140000000.2"))
 }
 
+pub fn try_fmt_float_really_large_negative_test() {
+  fmglee.new("%f")
+  |> fmglee.f(-140_000_000.2)
+  |> fmglee.try_build
+  |> should.equal(Ok("-140000000.2"))
+}
+
 pub fn try_fmt_float_trailing_test() {
   fmglee.new("%f")
   |> fmglee.f(140_000_000.0)
   |> fmglee.try_build
   |> should.equal(Ok("140000000.0"))
+}
+
+pub fn try_fmt_float_trailing_negative_test() {
+  fmglee.new("%f")
+  |> fmglee.f(-140_000_000.0)
+  |> fmglee.try_build
+  |> should.equal(Ok("-140000000.0"))
 }

--- a/test/fmglee_test.gleam
+++ b/test/fmglee_test.gleam
@@ -108,3 +108,24 @@ pub fn try_fmt_float_round_no_remainder_test() {
   |> fmglee.try_build
   |> should.equal(Ok("1234"))
 }
+
+pub fn try_fmt_float_really_small_test() {
+  fmglee.new("%.9f")
+  |> fmglee.f(0.000001415926)
+  |> fmglee.try_build
+  |> should.equal(Ok("0.000001415"))
+}
+
+pub fn try_fmt_float_really_large_test() {
+  fmglee.new("%f")
+  |> fmglee.f(140_000_000.2)
+  |> fmglee.try_build
+  |> should.equal(Ok("140000000.2"))
+}
+
+pub fn try_fmt_float_trailing_test() {
+  fmglee.new("%f")
+  |> fmglee.f(140_000_000.0)
+  |> fmglee.try_build
+  |> should.equal(Ok("140000000.0"))
+}


### PR DESCRIPTION
Thanks for the useful package! The JS regex wouldn't compile (I did the same thing in my gtempo package haha), and the erlang floats where not formatting correctly when they were > 1000.0 or < 0.0001. This PR should fix these two things. Thanks again!